### PR TITLE
Fix syntax used in annotation attribute value

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Now we need to integrate the library with Spring. In order to enable schedule lo
 ```java
 @Configuration
 @EnableScheduling
-@EnableSchedulerLock(defaultLockAtMostFor = "10m)
+@EnableSchedulerLock(defaultLockAtMostFor = "10m")
 class MySpringConfiguration {
     ...
 }


### PR DESCRIPTION
Nice library!
I've found this little documentation bug.